### PR TITLE
fix: exclude CHANGELOG.md from formatting/linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "scripts": {
     "build": "yarn tsc",
     "format": "prettier-package-json --write && yarn format:all --write",
-    "format:all": "prettier --loglevel warn '**/*.{js,ts,json,md}' '!dist/**' '!.github/ISSUE_TEMPLATE.md'",
+    "format:all": "prettier --loglevel warn '**/*.{js,ts,json,md}' '!CHANGELOG.md' '!dist/**' '!.github/ISSUE_TEMPLATE.md'",
     "lint": "yarn lint:js && yarn lint:md",
     "lint:js": "eslint bin/ src/ --ext js,ts --max-warnings 0",
-    "lint:md": "markdownlint ./*.md src/**/*.md",
+    "lint:md": "markdownlint README.md src/**/*.md",
     "prepare": "yarn build",
     "start": "bin/index.js",
     "tag": "[ `git rev-parse --abbrev-ref HEAD` = 'master' ] && standard-version --no-verify",


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Fix broken [test](https://app.circleci.com/pipelines/github/zendeskgarden/scripts/36/workflows/83c8ae09-d170-4260-96ab-0f15cf542b0d/jobs/53).