### PR TITLE
fix: override default auto merge for `github-deploy`

### DIFF
--- a/src/github/deploy/index.ts
+++ b/src/github/deploy/index.ts
@@ -52,6 +52,7 @@ export const execute = async (args: IGitHubDeployArgs): Promise<string | undefin
       ref,
       environment,
       description: args.message,
+      auto_merge: false,
       required_contexts: [],
       transient_environment: environment !== 'production'
     });


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Set `auto_merge: false` for `createDeployment`. See https://developer.github.com/v3/repos/deployments/#create-a-deployment for details.

## Detail

To prevent error as seen here: https://app.circleci.com/pipelines/github/zendeskgarden/react-components/541/workflows/fdccdbb1-e67a-4bd0-b8d5-85f0fb76b4c3/jobs/889/parallel-runs/0/steps/0-103
