### PR TITLE
fix: branch retrieval for travis PR jobs

### DIFF
--- a/src/github/branch/index.ts
+++ b/src/github/branch/index.ts
@@ -20,7 +20,10 @@ import execa from 'execa';
  * variable or extracted from the given git repository.
  */
 export const execute = async (path?: string, spinner?: Ora): Promise<string | undefined> => {
-  let retVal: string | undefined = process.env.CIRCLE_BRANCH || process.env.TRAVIS_BRANCH;
+  let retVal: string | undefined =
+    process.env.CIRCLE_BRANCH ||
+    process.env.TRAVIS_PULL_REQUEST_BRANCH ||
+    process.env.TRAVIS_BRANCH;
 
   if (!retVal) {
     const args = ['branch', '--show-current'];


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

On PR jobs, Travis uses `TRAVIS_BRANCH` to denote the _target_ branch (aka "master"). The `TRAVIS_PULL_REQUEST_BRANCH` will be available to identify the _originating_ PR branch.

## Detail

See https://docs.travis-ci.com/user/environment-variables/
