### PR TITLE
fix: commit retrieval for travis PR jobs

### DIFF
--- a/src/github/commit/index.ts
+++ b/src/github/commit/index.ts
@@ -30,7 +30,8 @@ interface IGitHubCommitArgs {
  * environment variable or remote GitHub commits for the given git repository.
  */
 export const execute = async (args: IGitHubCommitArgs = {}): Promise<string | undefined> => {
-  let retVal: string | undefined = process.env.CIRCLE_SHA1 || process.env.TRAVIS_COMMIT;
+  let retVal: string | undefined =
+    process.env.CIRCLE_SHA1 || process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT;
 
   if (!retVal) {
     try {


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The `TRAVIS_COMMIT` isn't what we're looking for. On PRs, the variable to check is `TRAVIS_PULL_REQUEST_SHA`.

## Detail

From https://docs.travis-ci.com/user/environment-variables/

> Rather than build the commits that have been pushed to the branch the pull request is from, we build the merge between the source branch and the upstream branch.
