### PR TITLE
fix: correctly parse `github-repository` owner and repo

### DIFF
--- a/src/github/repository/index.ts
+++ b/src/github/repository/index.ts
@@ -56,7 +56,7 @@ export const execute = async (path?: string, spinner?: Ora): Promise<RETVAL | un
 
         retVal = { owner, repo };
       } else {
-        handleErrorMessage(`Unexpected remote: ${remote}`, 'github-repository', spinner);
+        handleErrorMessage(`Unexpected remote URL: ${remote}`, 'github-repository', spinner);
       }
     } catch (error) {
       handleErrorMessage(error, 'github-repository', spinner);


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Use regex to handle both HTTPS and SSH GitHub URLs.

## Detail

i.e. works with `https://github.com/zendeskgarden/scripts.git` or `git@github.com:zendeskgarden/scripts.git`
