### PR TITLE
fix(deps): roll back is-interactive to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "execa": "5.1.1",
     "figlet": "1.5.0",
     "gh-pages": "3.2.3",
-    "is-interactive": "2.0.0",
+    "is-interactive": "1.0.0",
     "lerna-changelog": "1.0.1",
     "netlify": "6.1.29",
     "ora": "5.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2548,12 +2548,7 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-interactive@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-2.0.0.tgz#40c57614593826da1100ade6059778d597f16e90"
-  integrity sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==
-
-is-interactive@^1.0.0:
+is-interactive@1.0.0, is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==


### PR DESCRIPTION
## Description

This PR rolls back #72 because `is-interactive` v2 only supports ESM. This is problematic for projects that use `ora` and rely on `is-interactive` v1.

