### PR TITLE
fix(netlify-bandwidth): add missing args default

### DIFF
--- a/src/netlify/bandwidth/index.ts
+++ b/src/netlify/bandwidth/index.ts
@@ -32,7 +32,7 @@ type RETVAL = {
  *
  * @returns {object} The Netlify available and used bandwidth byte counts.
  */
-export const execute = async (args: INetlifyBandwidthArgs): Promise<RETVAL | undefined> => {
+export const execute = async (args: INetlifyBandwidthArgs = {}): Promise<RETVAL | undefined> => {
   let retVal: RETVAL | undefined;
 
   try {


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Need `args = {}` default when all args are optional.
