### PR TITLE
chore(circle-ci): add cache version environment variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
+          cache-version: '{{ .Environment.CACHE_VERSION }}'
       - persist_to_workspace:
           root: *workspace_root
           paths: .


### PR DESCRIPTION
## Description

Adds the `CACHE_VERSION` environment variable as the cache version for installed packages.
