### PR TITLE
fix(lerna-changelog): dynamic ESM import

### DIFF
--- a/src/lerna/changelog/index.ts
+++ b/src/lerna/changelog/index.ts
@@ -45,7 +45,7 @@ export const execute = async (args: ILernaChangelogArgs = {}): Promise<string | 
       describeArgs.unshift('-C', args.path);
     }
 
-    const fromPath = (await import('lerna-changelog/lib/configuration')).fromPath;
+    const fromPath = (await import('lerna-changelog/lib/configuration.js')).fromPath;
     const rootPath = await execa('git', revParseArgs);
     const config = fromPath(rootPath.stdout);
     const changelog = new Changelog(config);

--- a/typings/lerna-changelog/index.d.ts
+++ b/typings/lerna-changelog/index.d.ts
@@ -6,4 +6,4 @@
  */
 
 declare module 'lerna-changelog';
-declare module 'lerna-changelog/lib/configuration';
+declare module 'lerna-changelog/lib/configuration.js';


### PR DESCRIPTION
## Description

Per rules of ESM, need to provide the `.js` extension, otherwise import errors out.

## Detail

Had tested this command for #180, but didn't get through a full execution until attempting `yarn run tag` on `react-components` 😬
