### PR TITLE
chore: CI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
     <<: *executor
     steps:
       - checkout
+      - run: yarn global add node-gyp
       - node/install-packages:
           pkg-manager: yarn
           cache-version: '{{ .Environment.CACHE_VERSION }}'


### PR DESCRIPTION
## Description

Draft PR to go back and kick the CI tires with `node-gyp` global install.
