### PR TITLE
fix(netlify-deploy): prevent monorepo sites prompt

### DIFF
--- a/src/netlify/deploy/index.ts
+++ b/src/netlify/deploy/index.ts
@@ -47,6 +47,7 @@ export const execute = async (args: INetlifyDeployArgs): Promise<RETVAL | undefi
       'deploy',
       `--site=${siteId}`,
       `--auth=${token}`,
+      `--cwd=${args.dir}`,
       `--dir=${args.dir}`,
       '--json'
     ];


### PR DESCRIPTION
## Description

CI deploys silently [hang](https://app.circleci.com/pipelines/github/zendeskgarden/css-components/1204/workflows/569732c6-1392-4a4d-9368-89e4976d384d/jobs/2423) since `netlify-cli` v16 where a "sites" prompt was added when a monorepo is detected. This PR adds the undocumented `--cwd` flag to prevent netlify from triggering monorepo detection.

## Detail

See https://github.com/netlify/cli/issues/5977
