### PR TITLE
feat(githubRepository): support env var REPO_SLUG to return owner + repo value

### DIFF
--- a/src/github/repository/index.ts
+++ b/src/github/repository/index.ts
@@ -27,8 +27,9 @@ type RETVAL = {
 export const execute = async (path?: string, spinner?: Ora): Promise<RETVAL | undefined> => {
   let retVal: RETVAL | undefined;
 
-  if (process.env.TRAVIS_REPO_SLUG) {
-    const [owner, repo] = process.env.TRAVIS_REPO_SLUG.split('/') as [string, string];
+  if (process.env.TRAVIS_REPO_SLUG || process.env.REPO_SLUG) {
+    const slug = process.env.TRAVIS_REPO_SLUG || process.env.REPO_SLUG;
+    const [owner, repo] = slug!.split('/') as [string, string];
 
     retVal = { owner, repo };
   } else if (process.env.CIRCLECI) {


### PR DESCRIPTION
## Description
- returns owner + repo value from REPO_SLUG env var

## Detail

Can be with the `deploy` script in Github action as such:

```yaml
- name: Deploy
  run: utils/scripts/deploy.mjs
  env:
    NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
    REPO_SLUG: ${{ github.repository }}
```

