### PR TITLE
feat(github-pages): add option for disabling Jekyll deployments

### DIFF
--- a/src/github/pages/README.md
+++ b/src/github/pages/README.md
@@ -9,6 +9,7 @@ import { githubPages } from '@zendeskgarden/scripts';
 
 const args: {
   dir: string;
+  disableJekyll?: boolean;
   path?: string;
   message?: string;
   token?: string;
@@ -27,6 +28,7 @@ const args: {
 ### Arguments
 
 - `dir` directory of web content to publish.
+- `no-jekyll` disable Jekyll by adding a `.nojekyll` file.
 - `path` optional path to a git directory; defaults to `dir`.
 - `message` optional commit message.
 - `token` optional GitHub personal access token; defaults to the value
@@ -35,7 +37,7 @@ const args: {
 ## Command
 
 ```sh
-garden github-pages [--path <path>] [--message <message>] [--token <token>] <dir>
+garden github-pages [--no-jekyll] [--path <path>] [--message <message>] [--token <token>] <dir>
 ```
 
 To get debug output:

--- a/src/github/pages/index.ts
+++ b/src/github/pages/index.ts
@@ -14,6 +14,7 @@ import { execa } from 'execa';
 
 interface IGitHubPagesArgs {
   dir: string;
+  disableJekyll?: boolean;
   path?: string;
   message?: string;
   token?: string;
@@ -24,6 +25,7 @@ interface IGitHubPagesArgs {
  * Execute the `github-pages` command.
  *
  * @param {string} args.dir Folder to publish.
+ * @param {boolean} [args.disableJekyll] Disable Jekyll.
  * @param {string} [args.path] Path to a git directory.
  * @param {string} [args.message] Commit message.
  * @param {string} [args.token] GitHub personal access token.
@@ -62,6 +64,7 @@ export const execute = async (args: IGitHubPagesArgs): Promise<string | undefine
             email
           },
           message,
+          nojekyll: args.disableJekyll,
           silent: true
         },
         error => {
@@ -93,6 +96,7 @@ export default (spinner: Ora): Command => {
     .option('-p, --path <path>', 'git directory')
     .option('-t, --token <token>', 'access token')
     .option('-m, --message <message>', 'commit message')
+    .option('-n, --no-jekyll', 'disable Jekyll')
     .action(async dir => {
       try {
         spinner.start();
@@ -100,6 +104,7 @@ export default (spinner: Ora): Command => {
         const options = command.opts();
         const url = await execute({
           dir,
+          disableJekyll: !options.jekyll,
           path: options.path,
           message: options.message,
           token: options.token,


### PR DESCRIPTION
## Description

Flows through to the [gh-pages option](https://github.com/tschaub/gh-pages?tab=readme-ov-file#optionsnojekyll), enabling deployments, such as the ESLint Inspector on `eslint-config` that is failing because `_nuxt` is incorrectly determined to be a private Jekyll directory on GitHub.

## Detail

I verified this options fixes https://zendeskgarden.github.io/eslint-config/ via a local `garden github-pages` deploy.
