### PR TITLE
fix: get commit SHA from API rather than using inconsistent `GITHUB_SHA`

### DIFF
--- a/src/github/commit/index.ts
+++ b/src/github/commit/index.ts
@@ -32,10 +32,7 @@ interface IGitHubCommitArgs {
  */
 export const execute = async (args: IGitHubCommitArgs = {}): Promise<string | undefined> => {
   let retVal: string | undefined =
-    process.env.GITHUB_SHA ||
-    process.env.CIRCLE_SHA1 ||
-    process.env.TRAVIS_PULL_REQUEST_SHA ||
-    process.env.TRAVIS_COMMIT;
+    process.env.CIRCLE_SHA1 || process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT;
 
   if (!retVal) {
     try {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix: error
     reporting". the title informs the semantic version bump if this
     PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description
According to the [pull_request event docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request:~:text=Note%20that%20GITHUB_SHA%20for%20this%20event%20is%20the%20last%20merge%20commit%20of%20the%20pull%20request%20merge%20branch.%20If%20you%20want%20to%20get%20the%20commit%20ID%20for%20the%20last%20commit%20to%20the%20head%20branch%20of%20the%20pull%20request%2C%20use%20github.event.pull_request.head.sha%20instead.):

> `GITHUB_SHA` for the pull_request event is the last merge commit of the pull request merge branch.

>`github.event.pull_request.head.sha` is the commit SHA for the last commit to the head branch of the pull request. 

Because the `GITHUB_SHA` depends on the event that [triggered](https://docs.github.com/en/actions/learn-github-actions/variables#using-the-env-context-to-access-environment-variable-values:~:text=The%20commit%20SHA%20that%20triggered%20the%20workflow.%20The%20value%20of%20this%20commit%20SHA%20depends%20on%20the%20event%20that%20triggered%20the%20workflow.%20For%20more%20information%2C%20see%20%22Events%20that%20trigger%20workflows.%22) the workflow, leveraging its use may not always return the desired value.

Using the API, however, consistently returns the desired SHA regardless the workflow triggering event.
 
