### PR TITLE
fix(cmd-docgen): check for `undefined` default value

### DIFF
--- a/src/cmd/docgen/index.ts
+++ b/src/cmd/docgen/index.ts
@@ -103,7 +103,7 @@ export const execute = async (
             let defaultValue = prop.defaultValue?.value?.toString();
 
             if (
-              (type === 'string' && defaultValue !== null) ||
+              (type === 'string' && defaultValue !== null && defaultValue !== undefined) ||
               type.includes(`'${defaultValue}'`)
             ) {
               // Surround default string literals with quotes.


### PR DESCRIPTION
## Description

This PR fixes the `'undefined'` default values currently seen in the website [API prop sheets](https://garden.zendesk.com/components/combobox#combobox).
