### PR TITLE
fix(docgen): downgrade to `react-docgen-typescript@2.2.2` for correct component name parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "lodash": "4.17.21",
         "ora": "9.0.0",
         "pluralize": "8.0.0",
-        "react-docgen-typescript": "2.4.0",
+        "react-docgen-typescript": "2.2.2",
         "typescript": "5.9.3"
       },
       "bin": {
@@ -10018,9 +10018,10 @@
       }
     },
     "node_modules/react-docgen-typescript": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
-      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
+      "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">= 4.3.x"
       }
@@ -19736,9 +19737,9 @@
       "dev": true
     },
     "react-docgen-typescript": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
-      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
+      "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lodash": "4.17.21",
     "ora": "9.0.0",
     "pluralize": "8.0.0",
-    "react-docgen-typescript": "2.4.0",
+    "react-docgen-typescript": "2.2.2",
     "typescript": "5.9.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This PR downgrades `react-docgen-typescript` used by `docgen` to `2.2.2`. 

## Detail

`react-docgen-typescript@2.4.0` inconsistently extracts component `displayName` values depending on whether additional property assignments (like `propTypes`) exist between the displayName declaration and the export statement. This triggers different validation paths that handle component aliasing patterns differently, causing incorrect component name resolution in some cases while working correctly in others.
